### PR TITLE
Extend manager error reporting; add derived traits

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,6 +4,8 @@
 //! volume or mute. `GetVolumeSubscription` is different in that it subscribes to announcements
 //! from the TV regarding any changes in the volume or mute setting.
 
+use std::fmt;
+
 use serde_json::{Map, Value};
 
 use crate::{
@@ -14,7 +16,7 @@ use crate::{
 const GET_VOLUME_SUBSCRIPTION_ID: &str = "get_volume_subscription";
 
 /// LG control commands.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum TvCommand {
     /// Get current software information for the TV.
@@ -40,6 +42,17 @@ pub enum TvCommand {
     VolumeDown,
     /// Increase the volume level by one step.
     VolumeUp,
+}
+
+impl fmt::Display for TvCommand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TvCommand::SetMute(val) => write!(f, "SetMute({})", val),
+            TvCommand::SetScreenOn(val) => write!(f, "SetScreenOn({})", val),
+            TvCommand::SetVolume(val) => write!(f, "SetVolume({})", val),
+            variant => write!(f, "{:?}", variant),
+        }
+    }
 }
 
 impl From<TvCommand> for String {
@@ -181,7 +194,7 @@ impl From<TvCommand> for String {
 mod tests {
     use super::TvCommand;
 
-    // LGCommand payload string creation. These assume that serde will always serialize keys in
+    // TvCommand payload string creation. These assume that serde will always serialize keys in
     // the same order.
 
     #[test]
@@ -306,5 +319,24 @@ mod tests {
             payload,
             r#"{"type":"request","id":"test-id","uri":"ssap://audio/volumeUp","payload":null}"#
         );
+    }
+
+    // TvCommand display
+
+    #[test]
+    fn tvcommand_display() {
+        assert_eq!(TvCommand::GetCurrentSWInfo.to_string(), "GetCurrentSWInfo");
+        assert_eq!(TvCommand::GetPowerState.to_string(), "GetPowerState");
+        assert_eq!(TvCommand::GetSystemInfo.to_string(), "GetSystemInfo");
+        assert_eq!(TvCommand::GetVolume.to_string(), "GetVolume");
+        assert_eq!(TvCommand::SetMute(true).to_string(), "SetMute(true)");
+        assert_eq!(TvCommand::SetMute(false).to_string(), "SetMute(false)");
+        assert_eq!(TvCommand::SetScreenOn(true).to_string(), "SetScreenOn(true)");
+        assert_eq!(TvCommand::SetScreenOn(false).to_string(), "SetScreenOn(false)");
+        assert_eq!(TvCommand::SetVolume(10).to_string(), "SetVolume(10)");
+        assert_eq!(TvCommand::SubscribeGetVolume.to_string(), "SubscribeGetVolume");
+        assert_eq!(TvCommand::TurnOff.to_string(), "TurnOff");
+        assert_eq!(TvCommand::VolumeDown.to_string(), "VolumeDown");
+        assert_eq!(TvCommand::VolumeUp.to_string(), "VolumeUp");
     }
 }

--- a/src/connection_settings.rs
+++ b/src/connection_settings.rs
@@ -1,7 +1,9 @@
+use std::fmt;
+
 use crate::discovery::LgTvDevice;
 
 /// Connection type.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Connection {
     /// Connection to a TV using a network name or IP address.
     Host(String, ConnectionSettings),
@@ -9,8 +11,23 @@ pub enum Connection {
     Device(LgTvDevice, ConnectionSettings),
 }
 
+impl fmt::Display for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Connection::Host(host, settings) => {
+                write!(f, "Connection to host '{}', {:?}", host, settings)
+            }
+            Connection::Device(device, settings) => write!(
+                f,
+                "Connection to UPnP device '{}', {:?}",
+                device.friendly_name, settings
+            ),
+        }
+    }
+}
+
 /// Settings to use when connecting to a TV. Can be created with [`ConnectionSettingsBuilder`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ConnectionSettings {
     pub is_tls: bool,
     pub force_pairing: bool,
@@ -81,7 +98,8 @@ impl ConnectionSettingsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{ConnectionSettings, ConnectionSettingsBuilder};
+    use super::{Connection, ConnectionSettings, ConnectionSettingsBuilder};
+    use crate::LgTvDevice;
 
     #[test]
     fn connection_settings_default() {
@@ -105,6 +123,29 @@ mod tests {
                 is_tls: false,
                 force_pairing: true,
             }
+        );
+    }
+
+    #[test]
+    fn connection_display_host() {
+        assert_eq!(
+            Connection::Host("127.0.0.1".to_string(), ConnectionSettings::default()).to_string(),
+            "Connection to host '127.0.0.1', ConnectionSettings { is_tls: true, force_pairing: false }"
+        );
+    }
+
+    #[test]
+    fn connection_display_device() {
+        assert_eq!(
+            Connection::Device(LgTvDevice {
+                friendly_name: "LG WebOS TV".to_string(),
+                model: "model".to_string(),
+                model_number: None,
+                serial_number: None,
+                url: "http://38.0.101.76:3000".to_string(),
+                udn: "uuid:00000000-0000-0000-0000-000000000000".to_string(),
+            }, ConnectionSettings::default()).to_string(),
+            "Connection to UPnP device 'LG WebOS TV', ConnectionSettings { is_tls: true, force_pairing: false }"
         );
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -11,7 +11,7 @@ use rupnp::ssdp::{SearchTarget, URN};
 const MEDIA_RENDERER: URN = URN::device("schemas-upnp-org", "MediaRenderer", 1);
 
 /// A UPnP Device representation of an LG TV.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct LgTvDevice {
     pub friendly_name: String,
     pub model: String,
@@ -25,7 +25,7 @@ impl fmt::Display for LgTvDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "'{}' ({}) [{}]",
+            "{} ({}) [{}]",
             self.friendly_name, self.model, self.udn
         )
     }
@@ -103,4 +103,28 @@ pub(crate) async fn discover_lgtv_devices() -> Result<Vec<LgTvDevice>, String> {
     );
 
     Ok(discovered_lgtv_devices)
+}
+
+// ================================================================================================
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::LgTvDevice;
+
+    #[test]
+    fn lgtvdevice_display() {
+        assert_eq!(
+            LgTvDevice {
+                friendly_name: "LG WebOS TV".to_string(),
+                model: "model".to_string(),
+                model_number: None,
+                serial_number: None,
+                url: "http://38.0.101.76:3000".to_string(),
+                udn: "uuid:00000000-0000-0000-0000-000000000000".to_string(),
+            }
+            .to_string(),
+            "LG WebOS TV (model) [uuid:00000000-0000-0000-0000-000000000000]"
+        )
+    }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -118,7 +118,7 @@ pub(crate) struct LgTvCommandResponse {
 // GetCurrentSwInformation
 
 /// TV software information for the managed LG TV.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CurrentSwInfoPayload {
     #[doc(hidden)]
     #[serde(rename = "returnValue")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,7 +11,7 @@ use crate::messages::GetSystemInfoPayload;
 const PERSISTED_STATE_FILE: &str = "lgtv_manager_data.json";
 
 /// Current TV state for the managed LG TV.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Hash)]
 pub struct TvState {
     pub power_state: Option<String>,
     pub volume: Option<u8>,
@@ -21,7 +21,7 @@ pub struct TvState {
 }
 
 /// TV information for the managed LG TV.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct TvInfo {
     pub receiver_type: String,
     pub model_name: String,


### PR DESCRIPTION
* Improved error granularity: In `ManagerOutputMessage`, changed `ManagerError(String)` to `Error(ManagerError)` where `ManagerError` is an enum
* Added `ManagerOutputMessage::Resetting` for when the manager resets
* Added `Display`, `Eq`, `Hash`, and `Copy` traits to various structs and enums