### PR TITLE
Add EmitAllState message, and LastSeenTv output message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ includes additional commands for reference).
     * Send `TvCommand` messages (e.g. increase volume) to the TV.
 3. Sends `ManagerOutputMessage` updates back to the caller:
     * After a successful connection:
+        * The `LastSeenTv`.
         * The `TvInfo` (e.g. model name).
         * The `TvInput` list (e.g. HDMI).
         * The `TvSoftwareInfo` (e.g. webOS version).
@@ -116,8 +117,8 @@ as the host, such as `ws://10.0.1.101:3000/`, in which case the host will be use
 When using `Connection::Device`, the WebSocket server URL is generated using the UPnP
 device url. This assumes the `wss://` scheme on port `3001`.
 
-After a successful connection, the manager will emit `TvInfo`, `TvInput`, `TvSoftwareInfo`,
-and `TvState` details.
+After a successful connection, the manager will emit `LastSeenTv`, `TvInfo`, `TvInput`,
+`TvSoftwareInfo`, and `TvState` details.
 
 #### Pairing and client keys
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,13 @@ use crate::messages::GetSystemInfoPayload;
 
 const PERSISTED_STATE_FILE: &str = "lgtv_manager_data.json";
 
+/// Information on the TV last connected to by the Manager.
+#[derive(Debug, Default, Clone, PartialEq, Hash)]
+pub struct LastSeenTv {
+    pub websocket_url: Option<String>,
+    pub client_key: Option<String>,
+}
+
 /// Current TV state for the managed LG TV.
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
 pub struct TvState {


### PR DESCRIPTION
* Caller can now request all state with `ManagerMessage::EmitAllState`.
* Manager now sends `ManagerOutputMessage::LastSeenTv` whenever a new TV connection is established.