### PR TITLE
Add support for reconnects and connection testing

### DIFF
--- a/examples/control.rs
+++ b/examples/control.rs
@@ -2,7 +2,7 @@ use env_logger;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
-use lgtv_manager::ManagerMessage::{Connect, Disconnect, SendTvCommand, ShutDown};
+use lgtv_manager::ManagerMessage::{Connect, Disconnect, SendTvCommand, ShutDown, TestConnection};
 use lgtv_manager::ManagerStatus::Disconnected;
 use lgtv_manager::{
     Connection, ConnectionSettings, LgTvManager, ManagerOutputMessage,
@@ -34,8 +34,9 @@ async fn main() -> Result<(), ()> {
                     println!("\n>>> Manager is disconnected and ready to receive messages");
                     println!(">>> SEND CONNECT ('c') COMMAND FIRST; TV IP MUST BE VALID");
                     println!(concat!(
-                        ">>> Enter command: c (connect), u (volume up), d (volume down), ",
-                        "i (disconnect), s (shut down)\n"
+                        ">>> Enter command:\n",
+                        ">>>    c (connect), u (volume up), d (volume down)\n",
+                        ">>>    t (test connection), i (disconnect), s (shut down)\n"
                     ));
                 }
             }
@@ -81,6 +82,12 @@ async fn main() -> Result<(), ()> {
                 "d" => {
                     to_manager_clone
                         .send(SendTvCommand(VolumeDown))
+                        .await
+                        .map_err(|_| ())?;
+                }
+                "t" => {
+                    to_manager_clone
+                        .send(TestConnection)
                         .await
                         .map_err(|_| ())?;
                 }

--- a/src/connection_settings.rs
+++ b/src/connection_settings.rs
@@ -31,6 +31,8 @@ impl fmt::Display for Connection {
 pub struct ConnectionSettings {
     pub is_tls: bool,
     pub force_pairing: bool,
+    pub initial_connect_retries: bool,
+    pub auto_reconnect: bool,
 }
 
 impl Default for ConnectionSettings {
@@ -52,11 +54,15 @@ impl Default for ConnectionSettings {
 /// ConnectionSettingsBuilder::new()
 ///     .with_no_tls()
 ///     .with_forced_pairing()
+///     .with_initial_connect_retries()
+///     .with_auto_reconnect()
 ///     .build();
 /// ```
 pub struct ConnectionSettingsBuilder {
     is_tls: bool,
     force_pairing: bool,
+    initial_connect_retries: bool,
+    auto_reconnect: bool,
 }
 
 impl Default for ConnectionSettingsBuilder {
@@ -70,7 +76,8 @@ impl ConnectionSettingsBuilder {
         Self {
             is_tls: true,
             force_pairing: false,
-            // auto_reconnect: false,
+            initial_connect_retries: false,
+            auto_reconnect: false,
         }
     }
 
@@ -84,11 +91,22 @@ impl ConnectionSettingsBuilder {
         self
     }
 
+    pub fn with_initial_connect_retries(mut self) -> Self {
+        self.initial_connect_retries = true;
+        self
+    }
+
+    pub fn with_auto_reconnect(mut self) -> Self {
+        self.auto_reconnect = true;
+        self
+    }
+
     pub fn build(&mut self) -> ConnectionSettings {
         ConnectionSettings {
             is_tls: self.is_tls,
             force_pairing: self.force_pairing,
-            // auto_reconnect: self.auto_reconnect,
+            initial_connect_retries: self.initial_connect_retries,
+            auto_reconnect: self.auto_reconnect,
         }
     }
 }
@@ -98,8 +116,9 @@ impl ConnectionSettingsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{Connection, ConnectionSettings, ConnectionSettingsBuilder};
     use crate::LgTvDevice;
+
+    use super::{Connection, ConnectionSettings, ConnectionSettingsBuilder};
 
     #[test]
     fn connection_settings_default() {
@@ -108,6 +127,8 @@ mod tests {
             ConnectionSettings {
                 is_tls: true,
                 force_pairing: false,
+                initial_connect_retries: false,
+                auto_reconnect: false,
             }
         );
     }
@@ -118,10 +139,14 @@ mod tests {
             ConnectionSettingsBuilder::new()
                 .with_no_tls()
                 .with_forced_pairing()
+                .with_initial_connect_retries()
+                .with_auto_reconnect()
                 .build(),
             ConnectionSettings {
                 is_tls: false,
                 force_pairing: true,
+                initial_connect_retries: true,
+                auto_reconnect: true,
             }
         );
     }
@@ -130,7 +155,7 @@ mod tests {
     fn connection_display_host() {
         assert_eq!(
             Connection::Host("127.0.0.1".to_string(), ConnectionSettings::default()).to_string(),
-            "Connection to host '127.0.0.1', ConnectionSettings { is_tls: true, force_pairing: false }"
+            "Connection to host '127.0.0.1', ConnectionSettings { is_tls: true, force_pairing: false, initial_connect_retries: false, auto_reconnect: false }"
         );
     }
 
@@ -145,7 +170,7 @@ mod tests {
                 url: "http://38.0.101.76:3000".to_string(),
                 udn: "uuid:00000000-0000-0000-0000-000000000000".to_string(),
             }, ConnectionSettings::default()).to_string(),
-            "Connection to UPnP device 'LG WebOS TV', ConnectionSettings { is_tls: true, force_pairing: false }"
+            "Connection to UPnP device 'LG WebOS TV', ConnectionSettings { is_tls: true, force_pairing: false, initial_connect_retries: false, auto_reconnect: false }"
         );
     }
 }

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -36,6 +36,14 @@ pub(crate) enum StateMachineUpdateMessage {
 // ------------------------------------------------------------------------------------------------
 // States, Inputs, Outputs
 
+/// Information about the active reconnect flow.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReconnectDetails {
+    pub url: String,
+    pub attempts: u64,
+    pub next_attempt_secs: u64,
+}
+
 /// Manager status.
 #[derive(Debug, Clone, PartialEq)]
 pub enum State {
@@ -53,12 +61,12 @@ pub enum State {
     Communicating(String),
     /// Disconnecting from the TV at the provided url.
     Disconnecting(String),
-    /// Attempting a reconnect to the provided url in the given number of seconds.
+    /// Attempting to re-connect to the TV.
     // This is a faked state of sorts. The state machine never technically enters this state, but
     // the LgTvManager manages the reconnecting state manually and wants to inform callers about
     // the reconnect status. This is hacky.
     // TODO: Can the reconnect state be formally handled by the state machine in a clean manner.
-    Reconnecting(String, u64),
+    Reconnecting(ReconnectDetails),
     /// An unrecoverable problem has occurred. The Manager is unresponsive and will only respond
     /// (at best) to `ManagerMessage::ShutDown` requests.
     // Cannot be transitioned into or out of. This state exists only so the LgTvManager can inform


### PR DESCRIPTION
Reconnects are optional and can be enabled separately for dropped connections and initial connection failures. Connection tests ping the WebSocket server and check for a pong response.

See the documentation changes (in `lib.rs` and `README.md`) for details on usage.

Interface changes:

- `ConnectionSettingsBuilder`: Added `with_initial_connect_retries()` and `with_auto_reconnect()`
- `ManagerMessage`: Added `CancelReconnect` and `TestConnection`
- `ManagerOutputMessage`: Added `IsConnectionOk(bool)` and `IsReconnectFlowActive(bool)`
- `ManagerStatus`: Added `Reconnecting(ReconnectDetails)`
    - `ReconnectDetails` includes  `url`, `attempts`, and `next_attempt_secs`