### PR TITLE
Add Wake-on-LAN support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,7 @@ dependencies = [
  "macaddr",
  "native-tls",
  "pin-utils",
+ "rand",
  "rupnp",
  "rust-fsm",
  "rust-fsm-dsl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +490,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -599,6 +611,7 @@ dependencies = [
  "rust-fsm-dsl",
  "serde",
  "serde_json",
+ "surge-ping",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -695,6 +708,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "object"
@@ -807,6 +826,48 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "pnet_base"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cf6fb3ab38b68d01ab2aea03ed3d1132b4868fa4e06285f29f16da01c5f4c"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688b17499eee04a0408aca0aa5cba5fc86401d7216de8a63fdf7a4c227871804"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea925b72f4bd37f8eab0f221bbe4c78b63498350c983ffa9dd4bcde7e030f56"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a005825396b7fe7a38a8e288dbc342d5034dac80c15212436424fef8ea90ba"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1120,6 +1181,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "surge-ping"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbf95ce4c7c5b311d2ce3f088af2b93edef0f09727fa50fbe03c7a979afce77"
+dependencies = [
+ "hex",
+ "parking_lot",
+ "pnet_packet",
+ "rand",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,7 +1336,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
+ "macaddr",
  "native-tls",
  "pin-utils",
  "rupnp",
@@ -604,6 +605,7 @@ dependencies = [
  "tungstenite",
  "url",
  "uuid",
+ "wol-rs",
 ]
 
 [[package]]
@@ -643,6 +645,12 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "memchr"
@@ -1528,6 +1536,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wol-rs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5a8a033ef9b208ec8b5946761958ed2b2693ac49b04f647fdc013000870b8f"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3.30"
 futures-util = "0.3.30"
 futures-channel = "0.3.30"
 log = "0.4.22"
+macaddr = "1.0.1"
 native-tls = "0.2.12"
 pin-utils = "0.1.0"
 rupnp = { version = "2.0.0", features = ["full_device_spec"] }
@@ -29,6 +30,7 @@ tokio-util = { version = "0.7.11", features = ["rt"] }
 tungstenite = "0.21.0"
 url = "2.5.2"
 uuid = { version = "1.10.0", features = ["v4"] }
+wol-rs = "1.0.1"
 
 [dev-dependencies]
 env_logger = "0.11.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.22"
 macaddr = "1.0.1"
 native-tls = "0.2.12"
 pin-utils = "0.1.0"
+rand = "0.8.5"
 rupnp = { version = "2.0.0", features = ["full_device_spec"] }
 rust-fsm = "0.7.0"
 rust-fsm-dsl = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rust-fsm = "0.7.0"
 rust-fsm-dsl = "0.7.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+surge-ping = "0.8.1"
 tokio = { version = "1.39.3", features = ["full"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 tokio-util = { version = "0.7.11", features = ["rt"] }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Asynchronous control manager for LG TVs.
 
-The `lgtv_manager` crate provides `LgTvManager`, which manages an asynchronous interface to LG
-TVs supporting the webOS SSAP WebSocket protocol.
+`LgTvManager` manages an asynchronous interface to LG TVs supporting the webOS SSAP WebSocket
+protocol.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ protocol.
 ### Features
 
 * UPnP discovery of LG TVs.
+* Connect to TV using discovered UPnP device details or host IP.
 * Connection pairing.
 * Sending LG commands to the connected TV.
-* Provides details on the connected TV (software versions, inputs, etc).
+* Details on the connected TV (software versions, inputs, etc).
 * Automatic reconnects.
 * Wake-on-LAN support.
 * Persists last-connected TV details between sessions.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 const GET_VOLUME_SUBSCRIPTION_ID: &str = "get_volume_subscription";
+const GET_POWER_STATE_SUBSCRIPTION_ID: &str = "get_power_state_subscription";
 
 /// LG control commands.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -48,6 +49,9 @@ pub enum TvCommand {
     /// Subscribe to volume updates, including mute.
     #[doc(hidden)]
     SubscribeGetVolume,
+    /// Subscribe to power state updates.
+    #[doc(hidden)]
+    SubscribeGetPowerState,
     /// Switch to the given input id on the TV.
     SwitchInput(String),
     /// Turn off the TV.
@@ -223,6 +227,16 @@ impl From<TvCommand> for String {
                     r#type: LgTvRequestType::Subscribe,
                     id: GET_VOLUME_SUBSCRIPTION_ID.into(),
                     uri: Some("ssap://audio/getVolume".to_string()),
+                    payload: None,
+                };
+
+                serde_json::to_string(&data).unwrap_or_else(|_| String::new())
+            }
+            TvCommand::SubscribeGetPowerState => {
+                let data = LgTvRequest {
+                    r#type: LgTvRequestType::Subscribe,
+                    id: GET_POWER_STATE_SUBSCRIPTION_ID.into(),
+                    uri: Some("ssap://com.webos.service.tvpower/power/getPowerState".to_string()),
                     payload: None,
                 };
 
@@ -436,6 +450,16 @@ mod tests {
         assert_eq!(
             payload,
             r#"{"type":"subscribe","id":"get_volume_subscription","uri":"ssap://audio/getVolume","payload":null}"#
+        );
+    }
+
+    #[test]
+    fn payload_subscribe_get_power_state() {
+        let payload: String = TvCommand::SubscribeGetPowerState.into();
+
+        assert_eq!(
+            payload,
+            r#"{"type":"subscribe","id":"get_power_state_subscription","uri":"ssap://com.webos.service.tvpower/power/getPowerState","payload":null}"#
         );
     }
 

--- a/src/connection_settings.rs
+++ b/src/connection_settings.rs
@@ -182,6 +182,7 @@ mod tests {
                 serial_number: None,
                 url: "http://38.0.101.76:3000".to_string(),
                 udn: "uuid:00000000-0000-0000-0000-000000000000".to_string(),
+                mac_addr: None,
             }, ConnectionSettings::default()).to_string(),
             "Connection to UPnP device 'LG WebOS TV', ConnectionSettings { is_tls: true, client_key: None, force_pairing: false, initial_connect_retries: false, auto_reconnect: false }"
         );

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -2,10 +2,13 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::net::{IpAddr, Ipv4Addr};
+use std::process::Command;
 use std::time::Duration;
 
 use futures::prelude::*;
-use log::{error, info};
+use log::{error, info, warn};
+use macaddr::MacAddr;
 use rupnp::ssdp::{SearchTarget, URN};
 
 const DISCOVERY_DURATION_SECS: u64 = 3;
@@ -20,11 +23,48 @@ pub struct LgTvDevice {
     pub serial_number: Option<String>,
     pub url: String,
     pub udn: String,
+    pub mac_addr: Option<String>,
 }
 
 impl fmt::Display for LgTvDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ({}) [{}]", self.friendly_name, self.model, self.udn)
+    }
+}
+
+/// Get the MAC address for the given IP.
+///
+/// This uses the "arp" CLI tool assumed to be available from the OS. If that tool is not
+/// available, or if the MAC address was otherwise not determined, then None is returned.
+pub(crate) fn mac_address_for_ip(ip: IpAddr) -> Option<String> {
+    match Command::new("arp").arg("-n").arg(ip.to_string()).output() {
+        Ok(output) => {
+            let output_str = String::from_utf8_lossy(&output.stdout);
+
+            for line in output_str.lines() {
+                if line.contains(&ip.to_string()) {
+                    let parts: Vec<&str> = line.trim().split_whitespace().collect();
+
+                    for part in parts {
+                        if part.parse::<MacAddr>().is_ok() {
+                            return Some(part.into());
+                        }
+                    }
+
+                    warn!("Could not determine MAC address; MAC not found in 'arp' output");
+                    return None;
+                }
+            }
+
+            None
+        }
+        Err(e) => {
+            warn!(
+                "Could not invoke the 'arp' tool to determine MAC address: {:?}",
+                e
+            );
+            None
+        }
     }
 }
 
@@ -70,6 +110,7 @@ pub(crate) async fn discover_lgtv_devices() -> Result<Vec<LgTvDevice>, String> {
                         serial_number: device.serial_number().map(|s| s.to_owned()),
                         url: device.url().to_string(),
                         udn: device.udn().to_string(),
+                        mac_addr: mac_address_for_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 3, 101))),
                     };
 
                     info!(
@@ -119,6 +160,7 @@ mod tests {
                 serial_number: None,
                 url: "http://38.0.101.76:3000".to_string(),
                 udn: "uuid:00000000-0000-0000-0000-000000000000".to_string(),
+                mac_addr: None,
             }
             .to_string(),
             "LG WebOS TV (model) [uuid:00000000-0000-0000-0000-000000000000]"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,9 @@
 //! Helper functions.
 
+use core::net::IpAddr;
+
 use serde_json::Value;
-use url::Url;
+use url::{Host, Url};
 #[cfg(not(test))]
 use uuid::Uuid;
 
@@ -21,6 +23,22 @@ pub(crate) fn generate_lgtv_message_id() -> String {
     let id = Uuid::new_v4().hyphenated().to_string();
 
     id
+}
+
+/// Extract the IP address from the given `url`.
+pub(crate) fn url_ip_addr(url: &str) -> Option<IpAddr> {
+    match Url::parse(url) {
+        Ok(parsed_url) => match parsed_url.host() {
+            Some(host) => match host {
+                Host::Ipv4(ipv4) => Some(IpAddr::V4(ipv4)),
+                Host::Ipv6(ipv6) => Some(IpAddr::V6(ipv6)),
+                // TODO: Consider converting a hostname into an IP address
+                _ => None,
+            },
+            None => None,
+        },
+        Err(_) => None,
+    }
 }
 
 /// Generate an LG registration payload.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 /*!
 Asynchronous control manager for LG TVs.
 
-The `lgtv_manager` crate provides [`LgTvManager`], which manages an asynchronous interface to LG
-TVs supporting the webOS SSAP WebSocket protocol.
+[`LgTvManager`] manages an asynchronous interface to LG TVs supporting the webOS SSAP WebSocket
+protocol.
 
 ## Features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1007,7 +1007,6 @@ impl LgTvManager {
                                 }
                             },
                             Output::HandleDisconnectError => {
-                                self.optionally_prepare_for_reconnect().await;
                                 self.force_manager_reset("A WebSocket disconnect error occurred").await;
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,6 +987,7 @@ impl LgTvManager {
                                 let _ = self.send_to_ws(WsMessage::Payload(payload)).await;
                             },
                             Output::DisconnectFromTv => {
+                                self.optionally_prepare_for_reconnect().await;
                                 self.initiate_disconnect_from_tv().await;
                             },
                             Output::HandleSuccessfulDisconnect => {
@@ -1006,6 +1007,7 @@ impl LgTvManager {
                                 }
                             },
                             Output::HandleDisconnectError => {
+                                self.optionally_prepare_for_reconnect().await;
                                 self.force_manager_reset("A WebSocket disconnect error occurred").await;
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1286,10 +1286,10 @@ impl LgTvManager {
         false
     }
 
-    /// TODO: Docs
+    /// Prepare the manager for a new reconnect cycle if reconnects are enabled.
+    ///
+    /// The reconnect flow won't begin until the state machine reaches the Disconnected state.
     async fn optionally_prepare_for_reconnect(&mut self) {
-        // Prepare the manager for a new reconnect cycle if reconnects are enabled.
-        // The reconnect flow won't begin until the state machine reaches the Disconnected state.
         if self.reconnect_flow_status == ReconnectFlowStatus::Cancelled {
             return;
         }
@@ -1654,7 +1654,7 @@ impl LgTvManager {
         }
     }
 
-    /// Initialize the manager from a new WebSocket connection.
+    /// Initialize the manager with TV information retrieved from a new WebSocket connection.
     ///
     /// Performs steps that need to take place at the beginning of a new TV connection, such as
     /// retrieving TV details and subscribing to TV updates.
@@ -1686,8 +1686,6 @@ impl LgTvManager {
         if let Some(current_connection) = &self.connection_details {
             self.last_good_connection = Some(current_connection.clone());
         }
-
-        // TODO: Inform ping task of the new host to ping
     }
 
     /// Initiate a disconnect from the TV.
@@ -2002,12 +2000,14 @@ impl LgTvManager {
             .await;
     }
 
-    /// TODO: Document
+    /// Determine the TV host_ip (an IpAddr) from the current WebSocket URL (a String).
     async fn set_host_ip_from_ws_url(&mut self) {
         if let Some(ws_url) = &self.ws_url {
             if let Some(ip_addr) = url_ip_addr(ws_url) {
                 let mut host_ip = self.tv_host_ip.lock().await;
                 *host_ip = Some(ip_addr);
+
+                // Inform the TV network checker of the new IP.
                 &self.tv_host_ip_notifier.notify_one();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,27 @@ Asynchronous control manager for LG TVs.
 The `lgtv_manager` crate provides [`LgTvManager`], which manages an asynchronous interface to LG
 TVs supporting the webOS SSAP WebSocket protocol.
 
-(`lgtv_manager` has only partial support for the full set of webOS commands; see [`TvCommand`].
-This crate was inspired by [LGWebOSRemote](https://github.com/klattimer/LGWebOSRemote), which
-includes additional commands for reference).
+## Features
 
-`LgTvManager`:
+* UPnP discovery of LG TVs.
+* Connection pairing.
+* Sending LG commands to the connected TV.
+* Provides details on the connected TV (software versions, inputs, etc).
+* Automatic reconnects.
+* Wake-on-LAN support.
+* Persists last-connected TV details between sessions.
+
+## Overview
+
+An `LgTvManager` instance:
 
 1. Handles the WebSocket connection to an LG TV, including pairing.
 2. Accepts [`ManagerMessage`] messages from the caller to:
+    * Perform UPnP discovery of LG TVs.
     * Connect, disconnect, shut down, etc.
-    * Send [`TvCommand`] messages (e.g. increase volume) to the TV.
+    * Send [`TvCommand`] messages (e.g. increase volume) to the connected TV.
+    * Perform WebSocket connection or network (ping) tests.
+    * Submit a Wake-on-LAN request to the last-seen TV.
 3. Sends [`ManagerOutputMessage`] updates back to the caller:
     * After a successful connection:
         * The [`LastSeenTv`].
@@ -21,11 +32,15 @@ includes additional commands for reference).
         * The [`TvInput`] list (e.g. HDMI).
         * The [`TvSoftwareInfo`] (e.g. webOS version).
         * The [`TvState`] (e.g. current volume level).
+        * Whether Wake-on-LAN available.
     * As required during the lifetime of a connection:
-        * Updates to the [`ManagerStatus`].
+        * Updates to the manager's [`ManagerStatus`].
         * Updates to the [`TvState`].
-    * Errors.
-4. Supports UPnP discovery of LG TVs.
+        * [`TestStatus`] updates for regular connection tests and network ping tests.
+    * As required in response to other manager actions:
+        * Discovered UPnP devices ([`LgTvDevice`])
+        * [`TestStatus`] updates for on-demand connection tests and network ping tests.
+    * Any manager or TV errors.
 
 To view the full documentation, clone the repository and run `cargo doc --open`.
 
@@ -43,9 +58,10 @@ Communication with `LgTvManager` is asynchronous. Commands are invoked on the TV
 [`ManagerOutputMessage`] back to the caller. However, any changes to the TV's state (like a new
 volume setting) will be passed back to the caller via [`ManagerOutputMessage::TvState`].
 
-`LgTvManager` also subscribes to volume and mute updates from the TV. This means volume or mute
-changes made by other sources, such as the TV's remote control, will be reflected in `TvState`
-updates. `TvState` contains the entire state of the TV at the time the message was sent.
+`LgTvManager` also subscribes to volume, mute, and power state updates from the TV. This means
+changes to these states made by other sources -- such as the TV's remote control -- will be
+reflected in `TvState` updates. `TvState` contains the entire state of the TV at the time the
+message was sent.
 
 Most use cases will rely on sending [`ManagerMessage::SendTvCommand`] messages to control the TV;
 and processing any received [`ManagerOutputMessage::TvState`] messages. This asynchronous pattern
@@ -107,6 +123,7 @@ to_manager
     .send(Connect(Connection::Host(
         "10.0.0.101".into(),
         ConnectionSettingsBuilder::new()
+            .with_no_tls()
             .with_forced_pairing()
             .with_initial_connect_retries()
             .with_auto_reconnect()
@@ -155,7 +172,7 @@ state. The flow is as follows:
 4. `Pairing`
 5. `Initializing`
 6. `Communicating`
-6. `Disconnecting`
+8. `Disconnecting`
 
 Most states can be safely ignored. It is enough to instantiate `LgTvManager`, send a
 [`ManagerMessage::Connect`] message, and then wait for the manager to enter the `Communicating`
@@ -180,6 +197,9 @@ current state of the reconnect flow. This is distinct from the manager state, wh
 to cycle through the normal connect phases when attempting to reconnect. The reconnect flow will
 end either upon successful connection, or when cancelled with [`ManagerMessage::CancelReconnect`].
 
+If the TV goes offline then the manager will attempt to ping the TV over the network at regular
+intervals until it responds, at which time standard reconnects will be attempted.
+
 ### Retrying initial connections
 
 When connecting to a TV for the first time during a single manager session, the initial connection
@@ -200,11 +220,19 @@ It is expected that the most common commands to send to the TV will be those tha
 state (such as `SetMute`, `VolumeUp`, etc). Any changes to the TV's state will be received via
 `TvState` updates from the manager, so invoking the "get" commands is usually not necessary.
 
-## Testing the connection
+## Testing the WebSocket connection
 
-The current validity of a TV connection can be tested using [`ManagerMessage::TestConnection`].
-The manager will respond with a [`ManagerOutputMessage::ConnectionTestStatus`]. For a connection
-test to pass, the TV must successfully respond to a ping over the existing WebSocket connection.
+The current validity of the WebSocket connection to the TV can be tested using
+[`ManagerMessage::TestConnection`]. The manager will respond with a
+[`ManagerOutputMessage::ConnectionTestStatus`]. For a connection test to pass, the TV must respond
+to a WebSocket ping over the existing WebSocket connection.
+
+## Testing the network visibility of the TV
+
+Whether the TV is currently visible on the network can be tested using
+[`ManagerMessage::TestTvOnNetwork`]. The manager will respond with a
+[`ManagerOutputMessage::TvOnNetworkTestStatus`]. For a network test to pass, the TV must respond to
+a network ICMP ping.
 
 ## Disconnecting
 
@@ -216,7 +244,7 @@ a disconnect, and can still accept future [`ManagerMessage::Connect`] messages. 
 
 The `lgtv_manager` crate is currently limited in scope. It only supports the [`TvCommand`] list
 found in `src/commands.rs`, and does not provide much in the way of configuration (such as timeout
-durations and automatic reconnects).
+durations, reconnect intervals, etc).
 
 Extending `LgTvManager` to support additional TV commands should be fairly trivial, although
 LG's SSAP protocol does not appear to be documented. A good place to start is the
@@ -461,6 +489,7 @@ pub use state_machine::{ReconnectDetails, State as ManagerStatus};
 
 // CHANNEL MESSAGES -------------------------------------------------------------------------------
 
+/// General test status.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TestStatus {
     Unknown,
@@ -643,11 +672,17 @@ impl LgTvManagerBuilder {
 //  - If anything unrecoverable happens, then the manager enters the Zombie state and can no
 //    longer do anything useful.
 
+/// TV reconnect flow status.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReconnectFlowStatus {
+    /// The manager is attempting to reconnect to the TV at regular intervals.
     Active,
+    /// The reconnect flow has been cancelled by the caller.
     Cancelled,
+    /// The manager is not attempting to reconnect to the TV (usually because the connection is
+    /// established and valid, or reconnects are disabled).
     Inactive,
+    /// The manager is waiting for the TV to reappear on the network and respond to ping requests.
     WaitingForTvOnNetwork,
 }
 
@@ -1217,8 +1252,6 @@ impl LgTvManager {
         self.emit_tv_inputs().await;
         self.emit_tv_software_info().await;
         self.emit_tv_state().await;
-        // TODO: Remove
-        // self.emit_is_tv_on_network().await;
         self.emit_is_wake_tv_available().await;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2039,15 +2039,6 @@ impl LgTvManager {
             .await;
     }
 
-    // /// Send the current `IsTvOnNetwork` state to the caller.
-    // async fn emit_is_tv_on_network(&mut self) {
-    //     let _ = self
-    //         .send_out(ManagerOutputMessage::IsTvOnNetwork(
-    //             self.is_tv_on_network.load(Ordering::SeqCst),
-    //         ))
-    //         .await;
-    // }
-
     /// Send the current `IsWakeTvAvailable` state to the caller.
     async fn emit_is_wake_tv_available(&mut self) {
         let _ = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,6 +670,11 @@ impl LgTvManagerBuilder {
 //    in the "Disconnected" state, the "Connect" Input will transition the state machine into the
 //    "Connecting" state *and* emit the "ConnectToTv" Output. The "ConnectToTv" output is then
 //    received by the manager, which proceeds to initiate the WebSocket connection.
+//  - The manager is concerned with two "alive" states:
+//      - The WebSocket connection to the TV (validated with WebSocket Ping/Pong).
+//      - The TV being visible on the network (validated with ICMP ping).
+//  - If the manager unexpectedly loses the connection to the TV then it will enter a reconnect
+//    loop.
 //  - If anything unrecoverable happens, then the manager enters the Zombie state and can no
 //    longer do anything useful.
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use directories::ProjectDirs;
 use log::debug;
+use macaddr::MacAddr;
 use serde::{Deserialize, Serialize};
 
 use crate::messages::GetSystemInfoPayload;
@@ -15,7 +16,7 @@ const PERSISTED_STATE_FILE: &str = "lgtv_manager_data.json";
 pub struct LastSeenTv {
     pub websocket_url: Option<String>,
     pub client_key: Option<String>,
-    pub mac_addr: Option<String>,
+    pub mac_addr: Option<MacAddr>,
 }
 
 /// Current TV state for the managed LG TV.
@@ -83,7 +84,7 @@ pub(crate) fn write_persisted_state(
 ) -> Result<(), String> {
     let data_file = get_data_file(data_dir)?;
 
-    return match File::create(data_file) {
+    match File::create(data_file) {
         Ok(mut file) => {
             let persisted_state = PersistedState {
                 ws_url: state.ws_url.clone(),
@@ -100,7 +101,7 @@ pub(crate) fn write_persisted_state(
             }
         }
         Err(e) => Err(format!("Error writing persisted state: {:?}", e)),
-    };
+    }
 }
 
 /// Get the path to the data file as a PathBuf, creating the directory if necessary.

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ const PERSISTED_STATE_FILE: &str = "lgtv_manager_data.json";
 pub struct LastSeenTv {
     pub websocket_url: Option<String>,
     pub client_key: Option<String>,
+    pub mac_addr: Option<String>,
 }
 
 /// Current TV state for the managed LG TV.
@@ -52,6 +53,7 @@ impl From<GetSystemInfoPayload> for TvInfo {
 pub(crate) struct PersistedState {
     pub ws_url: Option<String>,
     pub client_key: Option<String>,
+    pub mac_addr: Option<String>,
 }
 
 // ------------------------------------------------------------------------------------------------0
@@ -86,6 +88,7 @@ pub(crate) fn write_persisted_state(
             let persisted_state = PersistedState {
                 ws_url: state.ws_url.clone(),
                 client_key: state.client_key.clone(),
+                mac_addr: state.mac_addr.clone(),
             };
 
             match serde_json::to_string(&persisted_state) {

--- a/src/tv_network_check.rs
+++ b/src/tv_network_check.rs
@@ -5,11 +5,10 @@
 
 use std::io;
 use std::net::IpAddr;
-use std::pin::pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use rand::random;
 use surge_ping::{Client, Config, PingIdentifier, PingSequence};
 use tokio::{

--- a/src/tv_network_check.rs
+++ b/src/tv_network_check.rs
@@ -1,0 +1,172 @@
+use log::{error, info, warn};
+use std::net::IpAddr;
+use std::pin::pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use surge_ping::{Client, Config, PingIdentifier};
+use tokio::{
+    select,
+    sync::{Mutex, Notify},
+    time::Duration,
+};
+
+pub(crate) struct TvNetworkChecker {
+    pub is_tv_alive: Arc<AtomicBool>,
+
+    check: Arc<Notify>,
+    is_tv_alive_notify: Arc<Notify>,
+    tv_ip: Arc<Mutex<Option<IpAddr>>>,
+    tv_ip_notify: Arc<Notify>,
+}
+
+impl TvNetworkChecker {
+    pub fn new() -> Self {
+        TvNetworkChecker {
+            is_tv_alive: Arc::new(AtomicBool::new(false)),
+
+            check: Arc::new(Notify::new()),
+            is_tv_alive_notify: Arc::new(Notify::new()),
+            tv_ip: Arc::new(Mutex::new(None)),
+            tv_ip_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// TODO: Document
+    pub fn start(&mut self) -> (Arc<AtomicBool>, Arc<Notify>, Arc<AtomicBool>, Arc<Notify>) {
+        let is_tv_alive = Arc::clone(&self.is_tv_alive);
+        let is_tv_alive_notify = Arc::clone(&self.is_tv_alive_notify);
+        let tv_ip = Arc::clone(&self.tv_ip);
+        let tv_ip_notify = Arc::clone(&self.tv_ip_notify);
+        let check = Arc::clone(&self.check);
+
+        let is_pinging = Arc::new(AtomicBool::new(false));
+        let is_pinging_clone = Arc::clone(&is_pinging);
+        let is_pinging_notify = Arc::new(Notify::new());
+        let is_pinging_notify_clone = Arc::clone(&is_pinging_notify);
+
+        tokio::spawn(async move {
+            info!("STARTING ALIVE CHECK");
+
+            let mut ping_target_ip: Option<IpAddr> = None;
+
+            // TODO: Check unwrap()
+            let ping_client = Client::new(&Config::default()).unwrap();
+            let mut ping_interval = tokio::time::interval(Duration::from_secs(60));
+
+            loop {
+                select! {
+                    _ = ping_interval.tick() => {
+                        info!("PING INTERVAL");
+
+                        // Only ping the TV if we have an IP address and the TV is still thought to
+                        // be offline.
+                        if let Some(target_ip) = ping_target_ip {
+                            // if !is_tv_alive.load(Ordering::SeqCst) {
+                                TvNetworkChecker::check_tv(
+                                    &ping_client,
+                                    target_ip.clone(),
+                                    Arc::clone(&is_tv_alive),
+                                    is_tv_alive_notify.clone(),
+                                    is_pinging.clone(),
+                                    is_pinging_notify.clone(),
+                                ).await;
+                            // } else {
+                            //     info!("TV THOUGHT TO BE ALIVE, NOT PINGING");
+                            // }
+                        }
+                    }
+
+                    _ = tv_ip_notify.notified() => {
+                        ping_target_ip = tv_ip.lock().await.clone();
+                        check.notify_one();
+
+                        info!("PING IP ADDRESS RECEIVED: {:?}", &ping_target_ip);
+                    }
+
+                    _ = check.notified() => {
+                        info!("PING CHECK START REQUESTED");
+
+                        if let Some(target_ip) = ping_target_ip {
+                            TvNetworkChecker::check_tv(
+                                &ping_client,
+                                target_ip.clone(),
+                                Arc::clone(&is_tv_alive),
+                                is_tv_alive_notify.clone(),
+                                is_pinging.clone(),
+                                is_pinging_notify.clone(),
+                            ).await;
+                        } else {
+                            warn!("Alive check requested, but no TV IP address known");
+                        }
+                    }
+                }
+            }
+        });
+
+        (
+            self.is_tv_alive.clone(),
+            self.is_tv_alive_notify.clone(),
+            is_pinging_clone,
+            is_pinging_notify_clone,
+        )
+    }
+
+    /// TODO: Document
+    pub async fn set_tv_ip(&mut self, tv_ip: IpAddr) {
+        {
+            info!("SETTING IP HERE");
+            let mut ip = self.tv_ip.lock().await;
+            *ip = Some(tv_ip);
+        }
+
+        self.tv_ip_notify.notify_one();
+        self.check();
+    }
+
+    /// TODO: Document
+    pub fn check(&mut self) {
+        self.check.notify_one();
+    }
+
+    // Private ------------------------------------------------------------------------------------
+
+    /// TODO: Document
+    async fn check_tv(
+        ping_client: &Client,
+        tv_ip: IpAddr,
+        is_tv_alive: Arc<AtomicBool>,
+        is_tv_alive_notify: Arc<Notify>,
+        is_pinging: Arc<AtomicBool>,
+        is_pinging_notify: Arc<Notify>,
+    ) {
+        if is_pinging.load(Ordering::SeqCst) {
+            warn!("Network ping is already in progress; not starting new network ping");
+            return;
+        }
+
+        is_pinging.store(true, Ordering::SeqCst);
+        is_pinging_notify.notify_one();
+
+        info!("PINGING TV FROM STRUCT IMPL: {:?}", tv_ip);
+
+        let ping_payload = [0; 8];
+        let mut pinger = ping_client.pinger(tv_ip, PingIdentifier::from(1)).await;
+
+        // TODO: Look into what the first parameter should be
+        match pinger.ping(1.into(), &ping_payload).await {
+            Ok(_) => {
+                info!("TV IS ALIVE");
+                is_tv_alive.store(true, Ordering::SeqCst);
+            }
+            Err(e) => {
+                info!("TV NOT ALIVE");
+                is_tv_alive.store(false, Ordering::SeqCst);
+            }
+        }
+
+        is_tv_alive_notify.notify_one();
+
+        is_pinging.store(false, Ordering::SeqCst);
+        is_pinging_notify.notify_one();
+    }
+}

--- a/src/tv_network_check.rs
+++ b/src/tv_network_check.rs
@@ -42,7 +42,8 @@ impl TvNetworkChecker {
     }
 
     /// Start the network checker task. The task will run forever, checking the provided IP address
-    /// at regular intervals and immediately on request.
+    /// at regular intervals and immediately on request. The IP address can be changed while the
+    /// checker task is running.
     pub fn start(
         &mut self,
     ) -> Result<(Arc<AtomicBool>, Arc<Notify>, Arc<AtomicBool>, Arc<Notify>), io::Error> {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -179,7 +179,7 @@ impl LgTvWebSocket {
                                     if connection_test_start.is_some() {
                                         warn!("Connection test already in progress");
                                     } else {
-                                        info!("Initiating connection test");
+                                        debug!("Initiating connection test");
 
                                         if let Err(e) = ws_write.send(Message::Ping(vec!())).await {
                                             error!("Failed to send WebSocket ping while testing connection: {:?}", e);
@@ -217,10 +217,10 @@ impl LgTvWebSocket {
                                     }
                                 }
                                 Message::Ping(_) => {
-                                    debug!("WebSocket Ping");
+                                    debug!("Received WebSocket Ping");
                                 }
                                 Message::Pong(_) => {
-                                    debug!("WebSocket Pong");
+                                    debug!("Received WebSocket Pong");
 
                                     // A pong received while testing the connection means the
                                     // connection test passed

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -177,9 +177,9 @@ impl LgTvWebSocket {
                                 }
                                 WsMessage::TestConnection => {
                                     if connection_test_start.is_some() {
-                                        warn!("Connection test already in progress");
+                                        warn!("WebSocket connection test already in progress");
                                     } else {
-                                        debug!("Initiating connection test");
+                                        debug!("Initiating WebSocket connection test");
 
                                         if let Err(e) = ws_write.send(Message::Ping(vec!())).await {
                                             error!("Failed to send WebSocket ping while testing connection: {:?}", e);


### PR DESCRIPTION
This PR allows `LgTvManager` to perform Wake-on-LAN requests for the last-seen TV.

Changes in this PR to support Wake-on-LAN:

* Added `TvNetworkChecker` to perform regular-interval TV pings over ICMP (Wake-on-LAN is unavailable when the TV is not visible on the network).
* Changed `ManagerMessage` variants:
    * Added `TestTvOnNetwork`, `WakeLastSeenTv`.
* Changed `ManagerOutputMessage` variants:
    * Added `ConnectionTestStatus`, `TvOnNetworkTestStatus`, `ReconnectFlowStatus`.
    * Removed `IsConnectionOk`, `IsReconnectFlowActive`.
* Updated the reconnection flow to allow for the TV being off the network (Added `ReconnectFlowStatus::WaitingForTvOnNetwork`).
* Added `TestStatus` for use by new `ManagerOutputMessage::ConnectionTestStatus` and `ManagerOutputMessage::TvOnNetworkTestStatus`.
* Added a `url_ip_addr()` helper to get an `IpAddr` from a URL string.
* `LgTvManager` now registers a subscription for power state updates.
* Documentation has been updated.
* MAC addresses are now tracked in `LgTvDevice` and `LastSeenTv`, and persisted to disk.
* Updates to log entries.