### PR TITLE
Respect manual disconnects and unavailable ping checker

### DIFF
--- a/src/lgtv_manager/orchestration.rs
+++ b/src/lgtv_manager/orchestration.rs
@@ -401,7 +401,9 @@ impl LgTvManager {
     /// interval has passed, it initiates a conventional Connect flow using the previously-provided
     /// `Connection` details.
     pub(crate) async fn initiate_reconnect(&mut self, immediate: bool) {
-        if !self.is_tv_on_network.load(Ordering::SeqCst) {
+        if !self.is_tv_on_network.load(Ordering::SeqCst)
+            && self.tv_on_network_checker.is_operational
+        {
             warn!("Preventing reconnect attempt while TV host is down");
             return;
         }

--- a/src/tv_network_check.rs
+++ b/src/tv_network_check.rs
@@ -21,6 +21,7 @@ const ONE_MINUTE_SECS: u64 = 60;
 
 pub(crate) struct TvNetworkChecker {
     pub is_tv_on_network: Arc<AtomicBool>,
+    pub is_operational: bool,
 
     check: Arc<Notify>,
     is_tv_on_network_notify: Arc<Notify>,
@@ -32,6 +33,7 @@ impl TvNetworkChecker {
     pub fn new() -> Self {
         TvNetworkChecker {
             is_tv_on_network: Arc::new(AtomicBool::new(false)),
+            is_operational: false,
 
             check: Arc::new(Notify::new()),
             is_tv_on_network_notify: Arc::new(Notify::new()),
@@ -58,6 +60,8 @@ impl TvNetworkChecker {
         let is_pinging_notify_clone = Arc::clone(&is_pinging_notify);
 
         let ping_client = Client::new(&Config::default())?;
+
+        self.is_operational = true;
 
         tokio::spawn(async move {
             info!("Starting TV network checker");


### PR DESCRIPTION
* Automatic reconnects should not be performed when a manual disconnect is requested.
* When the network checker is unavailable, have the reconnect flow fall back on `Active` rather than `WaitingForTvOnNetwork`.