### PR TITLE
Extend power state to include processing string

### DIFF
--- a/src/lgtv_manager/orchestration.rs
+++ b/src/lgtv_manager/orchestration.rs
@@ -14,7 +14,7 @@ use crate::ssap_payloads::{LgTvResponse, LgTvResponsePayload};
 use crate::state_machine::{Input, State};
 use crate::websocket_client::{LgTvWebSocket, WsCommand, WsMessage};
 use crate::{
-    Connection, ManagerError, ManagerOutputMessage, ManagerStatus, ReconnectDetails,
+    Connection, ManagerError, ManagerOutputMessage, ManagerStatus, PowerState, ReconnectDetails,
     ReconnectFlowStatus, TvCommand,
 };
 
@@ -260,7 +260,7 @@ impl LgTvManager {
                         self.emit_tv_inputs().await;
                     }
                     LgTvResponsePayload::GetPowerState(power_state_payload) => {
-                        self.tv_state.power_state = Some(power_state_payload.state.clone());
+                        self.tv_state.power_state = Some((*power_state_payload).clone().into());
                         self.emit_tv_state().await;
                     }
                     LgTvResponsePayload::GetSystemInfo(system_info_payload) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,6 @@ pub use lgtv_manager::{
 };
 pub use lgtv_manager_builder::LgTvManagerBuilder;
 pub use ssap_payloads::{CurrentSwInfoPayload as TvSoftwareInfo, ExternalInput as TvInput};
-pub use state::{LastSeenTv, TvInfo, TvState};
+pub use state::{LastSeenTv, PowerState, TvInfo, TvState};
 pub use state_machine::{ReconnectDetails, State as ManagerStatus};
 pub use tv_commands::TvCommand;

--- a/src/ssap_payloads.rs
+++ b/src/ssap_payloads.rs
@@ -172,9 +172,10 @@ pub(crate) struct GetExternalInputListPayload {
 
 // GetPowerState
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct GetPowerStatePayload {
     pub state: String,
+    pub processing: Option<String>,
     #[serde(rename = "returnValue")]
     pub return_value: bool,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use macaddr::MacAddr;
 
-use crate::ssap_payloads::GetSystemInfoPayload;
+use crate::ssap_payloads::{GetPowerStatePayload, GetSystemInfoPayload};
 
 /// Information on the TV last connected to by the Manager.
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
@@ -10,10 +10,26 @@ pub struct LastSeenTv {
     pub mac_addr: Option<MacAddr>,
 }
 
+/// Current power state for the managed LG TV.
+#[derive(Debug, Default, Clone, PartialEq, Hash)]
+pub struct PowerState {
+    pub state: String,
+    pub processing: Option<String>,
+}
+
+impl From<GetPowerStatePayload> for PowerState {
+    fn from(power_state: GetPowerStatePayload) -> Self {
+        PowerState {
+            state: power_state.state,
+            processing: power_state.processing,
+        }
+    }
+}
+
 /// Current TV state for the managed LG TV.
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
 pub struct TvState {
-    pub power_state: Option<String>,
+    pub power_state: Option<PowerState>,
     pub volume: Option<u8>,
     pub is_muted: Option<bool>,
     pub is_screen_on: Option<bool>,


### PR DESCRIPTION
Replaces `TvState.power_state` with a new `PowerState` struct in place of the previous `String`.