### PR TITLE
Replace reconnect rate with exponential falloff

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ When the TV closes the connection (e.g. after the TV enters standby), the manage
 default `Disconnected` state. This behavior can be overridden with
 `ConnectionSettingsBuilder::with_auto_reconnect()`.
 
-When auto reconnect is enabled, the manager will attempt to reestablish a lost connection. Each
-reconnect is attempted after a 5s delay. The manager can be instructed to stop attempting
-reconnects by sending `ManagerMessage::CancelReconnect`.
+When auto reconnect is enabled, the manager will attempt to reestablish a lost connection. The wait
+time between reconnects will increase exponentially from 250ms to a maximum of 10 seconds. The
+manager can be instructed to stop attempting reconnects by sending
+`ManagerMessage::CancelReconnect`.
 
 The manager will emit `ManagerOutputMessage::ReconnectFlowStatus` messages to indicate the
 current state of the reconnect flow. This is distinct from the manager state, which will continue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,10 @@ When the TV closes the connection (e.g. after the TV enters standby), the manage
 default `Disconnected` state. This behavior can be overridden with
 [`ConnectionSettingsBuilder::with_auto_reconnect()`].
 
-When auto reconnect is enabled, the manager will attempt to reestablish a lost connection. Each
-reconnect is attempted after a 5s delay. The manager can be instructed to stop attempting
-reconnects by sending [`ManagerMessage::CancelReconnect`].
+When auto reconnect is enabled, the manager will attempt to reestablish a lost connection. The wait
+time between reconnects will increase exponentially from 250ms to a maximum of 10 seconds. The
+manager can be instructed to stop attempting reconnects by sending
+[`ManagerMessage::CancelReconnect`].
 
 The manager will emit [`ManagerOutputMessage::ReconnectFlowStatus`] messages to indicate the
 current state of the reconnect flow. This is distinct from the manager state, which will continue

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -41,7 +41,7 @@ pub(crate) enum StateMachineUpdateMessage {
 pub struct ReconnectDetails {
     pub url: String,
     pub attempts: u64,
-    pub next_attempt_secs: u64,
+    pub next_attempt_ms: u128,
 }
 
 /// Manager status.
@@ -66,7 +66,7 @@ pub enum State {
     // the LgTvManager manages the reconnecting state manually and wants to inform callers about
     // the reconnect status. This is hacky.
     // TODO: Can the reconnect state be formally handled by the state machine in a clean manner.
-    Reconnecting(ReconnectDetails),
+    WaitingToReconnect(ReconnectDetails),
     /// An unrecoverable problem has occurred. The Manager is unresponsive and will only respond
     /// (at best) to `ManagerMessage::ShutDown` requests.
     // Cannot be transitioned into or out of. This state exists only so the LgTvManager can inform


### PR DESCRIPTION
* Reconnects were previously attempted every 5s. This PR implements an exponential falloff from 250ms to 10s.
* `ReconnectDetails.next_attempt_secs` has been replaced with `next_attempt_ms`.
* Renamed `ManagerState::Reconnecting` to `ManagerState::WaitingToReconnect`.